### PR TITLE
Added support for geolocation data

### DIFF
--- a/msa/database.py
+++ b/msa/database.py
@@ -59,7 +59,7 @@ class MSADataBase:
             raise MSADatabaseConnectionException(
                 f'Database connection failed with: {issue!r}'
             )
-        self.metrics_table_name = 'webcheck'
+        self.metrics_table_name = 'geowebcheck'
 
     def delete_table(self) -> None:
         """
@@ -74,7 +74,7 @@ class MSADataBase:
         """
         Create table
 
-        ID | PAGE | DATE | STATUS | RTIME | TAG
+        ID | PAGE | DATE | STATUS | RTIME | TAG | GEO
 
         * ID: Self generated entry id
         * PAGE: Web page URI
@@ -82,6 +82,7 @@ class MSADataBase:
         * STATUS: Request status code
         * RTIME: Request response time
         * TAG: Free form tag data associated with request content
+        * GEO: Geo Location Information
         """
         create_table = dedent('''
             CREATE TABLE {table}
@@ -90,7 +91,8 @@ class MSADataBase:
             DATE     TIMESTAMP   NOT NULL,
             STATUS   INTEGER     NOT NULL,
             RTIME    REAL        NOT NULL,
-            TAG      TEXT)
+            TAG      TEXT,
+            GEO      TEXT)
         ''').format(table=self.metrics_table_name).strip()
         self.__execute(create_table)
 
@@ -110,7 +112,7 @@ class MSADataBase:
 
     def insert(
         self, url: str, date: str, status_code: int,
-        response_time: float, tag: str = None
+        response_time: float, tag: str = None, geo: str = None
     ) -> None:
         """
         Insert into table
@@ -126,15 +128,16 @@ class MSADataBase:
         )
         insert_into = dedent('''
             INSERT INTO {table}
-            (PAGE, DATE, STATUS, RTIME, TAG)
-            VALUES($${page}$$, '{date}', {status}, {rtime}, $${tag}$$)
+            (PAGE, DATE, STATUS, RTIME, TAG, GEO)
+            VALUES($${page}$$, '{date}', {status}, {rtime}, $${tag}$$, $${geo}$$)
         ''').format(
             table=self.metrics_table_name,
             page=url,
             date=request_date,
             status=status_code,
             rtime=response_time,
-            tag=tag if tag else 'NULL'
+            tag=tag if tag else 'NULL',
+            geo=geo if geo else 'NULL'
         ).strip()
         self.__execute(insert_into)
 

--- a/msa/kafka.py
+++ b/msa/kafka.py
@@ -64,7 +64,7 @@ class MSAKafka:
         self.kafka_ca = self.kafka_config['ssl_cafile']
         self.kafka_cert = self.kafka_config['ssl_certfile']
         self.kafka_key = self.kafka_config['ssl_keyfile']
-        self.schema_version = 0.1
+        self.schema_version = 0.2
 
     def send(self, metrics: MSAMetrics) -> None:
         """
@@ -81,7 +81,8 @@ class MSAKafka:
             'date': metrics.get_response_date(),
             'status': metrics.get_status_code(),
             'rtime': metrics.get_response_time(),
-            'tag': metrics.get_tag()
+            'tag': metrics.get_tag(),
+            'geo': metrics.get_geolocation()
         }
         message_broker.send(
             self.kafka_topic, yaml.dump(metrics_dict).encode()

--- a/msa/metrics.py
+++ b/msa/metrics.py
@@ -15,6 +15,8 @@
 # You should have received a copy of the GNU General Public License
 # along with MSA.  If not, see <http://www.gnu.org/licenses/>
 #
+import socket
+from urllib.request import Request
 from datetime import datetime
 from typing import Optional
 from msa.logger import MSALogger
@@ -45,6 +47,7 @@ class MSAMetrics:
         self.response_status_code = -1
         self.response_elapsed_total_seconds = -1.0
         self.content_matches_expression = False
+        self.geolocation = {}
         try:
             response = requests.get(url, timeout=timeout)
             self.response_status_code = response.status_code
@@ -54,8 +57,22 @@ class MSAMetrics:
                 self.content_matches_expression = bool(
                     re.match(f'{self.expression}', format(response.content))
                 )
+            source_ip = socket.gethostbyname(Request(url).host)
+            self.geolocation = requests.get(
+                f'https://geolocation-db.com/json/{source_ip}&position=true'
+            ).json()
         except requests.exceptions.RequestException as issue:
             log.error(f'Request failed with: {issue!r}')
+
+    def get_geolocation(self) -> str:
+        """
+        Return request geolocation details
+
+        :return: The geolocation dictionary as provided by geolocation-db.com
+
+        :rtype: Dict
+        """
+        return f'{self.geolocation}'
 
     def get_page(self) -> str:
         """

--- a/msa/msa_store.py
+++ b/msa/msa_store.py
@@ -105,5 +105,6 @@ def store_to_database(messages: List, db: MSADataBase):
             message['date'],
             message['status'],
             message['rtime'],
-            message['tag']
+            message['tag'],
+            message['geo']
         )

--- a/msa/transport_schema.py
+++ b/msa/transport_schema.py
@@ -41,5 +41,9 @@ transport_schema = {
         'required': True,
         'type': 'string',
         'nullable': True
+    },
+    'geo': {
+        'required': True,
+        'type': 'string'
     }
 }

--- a/test/unit/database_test.py
+++ b/test/unit/database_test.py
@@ -36,28 +36,29 @@ class TestMSADataBase:
     def test_delete_table(self):
         self.msa_db.delete_table()
         self.msa_db.db_cursor.execute.assert_called_once_with(
-            'DROP TABLE IF EXISTS webcheck'
+            'DROP TABLE IF EXISTS geowebcheck'
         )
 
     def test_create_table(self):
         self.msa_db.create_table()
-        create_table_webcheck = dedent('''
-            CREATE TABLE webcheck
+        create_table_geowebcheck = dedent('''
+            CREATE TABLE geowebcheck
             (ID INT GENERATED ALWAYS AS IDENTITY,
             PAGE     TEXT        NOT NULL,
             DATE     TIMESTAMP   NOT NULL,
             STATUS   INTEGER     NOT NULL,
             RTIME    REAL        NOT NULL,
-            TAG      TEXT)
+            TAG      TEXT,
+            GEO      TEXT)
         ''').strip()
         self.msa_db.db_cursor.execute.assert_called_once_with(
-            create_table_webcheck
+            create_table_geowebcheck
         )
 
     def test_dump_table(self):
         self.msa_db.dump_table()
         self.msa_db.db_cursor.execute.assert_called_once_with(
-            'SELECT * FROM webcheck'
+            'SELECT * FROM geowebcheck'
         )
 
     def test_insert_table(self):
@@ -65,24 +66,25 @@ class TestMSADataBase:
         self.msa_db.insert(
             'https://example.org', '2021-04-29T01:55:19+00:00', 404, 42
         )
-        insert_into_webcheck = dedent('''
-            INSERT INTO webcheck
-            (PAGE, DATE, STATUS, RTIME, TAG)
-            VALUES($$https://example.org$$, '2021-04-29 01:55:19', 404, 42, $$NULL$$)
+        insert_into_geowebcheck = dedent('''
+            INSERT INTO geowebcheck
+            (PAGE, DATE, STATUS, RTIME, TAG, GEO)
+            VALUES($$https://example.org$$, '2021-04-29 01:55:19', 404, 42, $$NULL$$, $$NULL$$)
         ''').strip()
         self.msa_db.db_cursor.execute.assert_called_once_with(
-            insert_into_webcheck
+            insert_into_geowebcheck
         )
         # test on insert with some tag
         self.msa_db.db_cursor.execute.reset_mock()
         self.msa_db.insert(
-            'https://example.org', '2021-04-29T01:55:19+00:00', 404, 42, 'tag'
+            'https://example.org', '2021-04-29T01:55:19+00:00',
+            404, 42, 'tag', 'geo'
         )
-        insert_into_webcheck = dedent('''
-            INSERT INTO webcheck
-            (PAGE, DATE, STATUS, RTIME, TAG)
-            VALUES($$https://example.org$$, '2021-04-29 01:55:19', 404, 42, $$tag$$)
+        insert_into_geowebcheck = dedent('''
+            INSERT INTO geowebcheck
+            (PAGE, DATE, STATUS, RTIME, TAG, GEO)
+            VALUES($$https://example.org$$, '2021-04-29 01:55:19', 404, 42, $$tag$$, $$geo$$)
         ''').strip()
         self.msa_db.db_cursor.execute.assert_called_once_with(
-            insert_into_webcheck
+            insert_into_geowebcheck
         )

--- a/test/unit/kafka_test.py
+++ b/test/unit/kafka_test.py
@@ -48,6 +48,7 @@ class TestMSAKafka:
         metrics.get_status_code.return_value = 42
         metrics.get_response_time.return_value = 'time'
         metrics.get_tag.return_value = None
+        metrics.get_geolocation.return_value = None
         self.kafka.send(metrics)
 
         mock_KafkaProducer.assert_called_once_with(
@@ -59,8 +60,8 @@ class TestMSAKafka:
         )
         message_broker.send.assert_called_once_with(
             'ms-intro',
-            b'date: date\npage: http://example.com\nrtime: '
-            b'time\nstatus: 42\ntag: null\nversion: 0.1\n'
+            b'date: date\ngeo: null\npage: http://example.com\nrtime: '
+            b'time\nstatus: 42\ntag: null\nversion: 0.2\n'
         )
 
     @patch('msa.kafka.KafkaConsumer')
@@ -134,8 +135,8 @@ class TestMSAKafka:
                 'topic_partition': [
                     message_type(
                         value=b'page: http://example.com\n'
-                        b'date: date\nstatus: 42\nrtime: 42\ntag: tag\n'
-                        b'version: 0.1\n'
+                        b'date: date\ngeo: geo\nstatus: 42\nrtime: 42\n'
+                        b'tag: tag\nversion: 0.2\n'
                     )
                 ]
             },
@@ -150,12 +151,13 @@ class TestMSAKafka:
 
         assert self.kafka.read() == [
             {
-                'version': 0.1,
+                'version': 0.2,
                 'page': 'http://example.com',
                 'date': 'date',
                 'status': 42,
                 'rtime': 42,
-                'tag': 'tag'
+                'tag': 'tag',
+                'geo': 'geo'
             }
         ]
 


### PR DESCRIPTION
Added support for geolocation data
    
Using the geolocation-db.com service to find out some
location information including the source ip information
as well. Complete information contains something
like this:
 
* https://www.heise.de
 
```yaml   
{
    'country_code': 'DE',
    'country_name': 'Germany',
    'city': 'Isernhagen',
    'postal': '30657',
    'latitude': 52.4382,
    'longitude': 9.7987,
    'IPv4': '193.99.144.85',
    'state': 'Lower Saxony'
}
```
    
This Fixes #1 and Fixes #2

