### PR TITLE
Added transport schema version

### DIFF
--- a/msa/kafka.py
+++ b/msa/kafka.py
@@ -64,6 +64,7 @@ class MSAKafka:
         self.kafka_ca = self.kafka_config['ssl_cafile']
         self.kafka_cert = self.kafka_config['ssl_certfile']
         self.kafka_key = self.kafka_config['ssl_keyfile']
+        self.schema_version = 0.1
 
     def send(self, metrics: MSAMetrics) -> None:
         """
@@ -75,6 +76,7 @@ class MSAKafka:
         """
         message_broker = self.__create_ssl_broker()
         metrics_dict = {
+            'version': self.schema_version,
             'page': metrics.get_page(),
             'date': metrics.get_response_date(),
             'status': metrics.get_status_code(),

--- a/msa/msa_store.py
+++ b/msa/msa_store.py
@@ -97,8 +97,9 @@ def main() -> None:
 
 def store_to_database(messages: List, db: MSADataBase):
     for message in messages:
-        log.info('Writing message to database...')
-        log.info(f'--> {message}')
+        log.info(
+            f'Writing metrics record for {message["page"]!r} to database...'
+        )
         db.insert(
             message['page'],
             message['date'],

--- a/msa/transport_schema.py
+++ b/msa/transport_schema.py
@@ -16,6 +16,11 @@
 # along with MSA.  If not, see <http://www.gnu.org/licenses/>
 #
 transport_schema = {
+    'version': {
+        'required': True,
+        'type': 'number',
+        'nullable': False
+    },
     'page': {
         'required': True,
         'type': 'string'

--- a/test/unit/kafka_test.py
+++ b/test/unit/kafka_test.py
@@ -60,7 +60,7 @@ class TestMSAKafka:
         message_broker.send.assert_called_once_with(
             'ms-intro',
             b'date: date\npage: http://example.com\nrtime: '
-            b'time\nstatus: 42\ntag: null\n'
+            b'time\nstatus: 42\ntag: null\nversion: 0.1\n'
         )
 
     @patch('msa.kafka.KafkaConsumer')
@@ -134,7 +134,8 @@ class TestMSAKafka:
                 'topic_partition': [
                     message_type(
                         value=b'page: http://example.com\n'
-                        b'date: date\nstatus: 42\nrtime: 42\ntag: tag'
+                        b'date: date\nstatus: 42\nrtime: 42\ntag: tag\n'
+                        b'version: 0.1\n'
                     )
                 ]
             },
@@ -149,6 +150,7 @@ class TestMSAKafka:
 
         assert self.kafka.read() == [
             {
+                'version': 0.1,
                 'page': 'http://example.com',
                 'date': 'date',
                 'status': 42,


### PR DESCRIPTION
To manage changes in the transport schema it is advisable
to add a version information such that incompatible message
types according to the used msa version can be detected